### PR TITLE
Bump passport-oauth / Add profile _raw and _json

### DIFF
--- a/lib/passport-arcgis/strategy.js
+++ b/lib/passport-arcgis/strategy.js
@@ -100,12 +100,8 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
       json.id = json.username;
 
-      //These two propertues can be useful for 
-      //debugging, but also make the profile object 
-      //pretty fat, so use judiciously
-      //profile._raw = body;
-      //profile._json = json;
-      //--------------------------------------
+      profile._raw = body;
+      profile._json = json;
 
       done(null, profile);
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-arcgis",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "1.0.0"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
Hey

This is my first pull request on Github, so tell me if there's anything wrong with it.

I bumped the passport-oauth version to 1.0.0 to make it compatible with passport 0.3.0.
(See issue DavidSpriggs/passport-arcgis#3)

Additionally I added the `profile._raw` and `profile._json` back in. These are not just debug objects, but they rather contain the actual user information from their ArcGIS Online profile and people might need those.
And all the other passport strategies leave them in there, so it's probably a safe thing to do.
(See issue DavidSpriggs/passport-arcgis#1)

Thanks for merging.

Best,
Sandro
